### PR TITLE
view sales of speecific product

### DIFF
--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -42,6 +42,10 @@ const ProductRoutes = props => {
         component={AddProduct}
       />
       <PrivateRoute path={`${props.match.path}/add`} component={AddProduct} />
+      <PrivateRoute
+        path={`${props.match.path}/:id/sales`}
+        component={SalesReports}
+      />
     </Switch>
   );
 };

--- a/src/components/tables/ProductsTable.js
+++ b/src/components/tables/ProductsTable.js
@@ -91,10 +91,13 @@ function ProductsTable(props) {
       Header: '',
       filterable: false,
       Cell: props => (
-        <div style={{ textAlign: 'center' }}>
+        <div>
+          <Button as={Link} primary to={`products/${props.original.id}/sales`}>
+            Ventas
+          </Button>
           <Button
             as={Link}
-            color="green"
+            color="teal"
             to={`/products/add/${props.original.id}`}
           >
             Editar

--- a/src/pages/landings/SalesReports.js
+++ b/src/pages/landings/SalesReports.js
@@ -12,6 +12,9 @@ import { SALESBYRANGE_QUERY } from '../../queries/sales';
 import { isAdmin } from '../../utils';
 
 function SalesReports(props) {
+  const { match } = props;
+  const { id } = match.params;
+
   const [startDate, setStartDate] = useState(startOfDay(new Date()));
   const [endDate, setEndDate] = useState(endOfDay(new Date()));
   const { user } = useContext(Context);
@@ -71,6 +74,7 @@ function SalesReports(props) {
         <Query
           query={SALESBYRANGE_QUERY}
           variables={{
+            id,
             from: startDate.toISOString(),
             to: endDate.toISOString(),
           }}

--- a/src/queries/sales.js
+++ b/src/queries/sales.js
@@ -36,8 +36,8 @@ export const SALES_QUERY = gql`
 `;
 
 export const SALESBYRANGE_QUERY = gql`
-  query SalesByRangeQuery($from: String!, $to: String!) {
-    salesbyrange(from: $from, to: $to) {
+  query SalesByRangeQuery($id: ID, $from: String!, $to: String!) {
+    salesbyrange(id: $id, from: $from, to: $to) {
       sum
       sales {
         number


### PR DESCRIPTION
Add a bottom in products table that route me to sales report table, and show the sales of the sepecific product. The thing is that always get the 'from' and 'to' dates, so, to see the sales, the dates must be change.